### PR TITLE
fix: deletion which does not exist

### DIFF
--- a/commit.sh
+++ b/commit.sh
@@ -24,8 +24,9 @@ git diff -z --name-only --cached --no-renames --diff-filter=d | \
     > "$TMPDIR/additions.txt"
 
 # deletions
+# shellcheck disable=SC2016
 git diff -z --name-only --cached --no-renames --diff-filter=D | \
-    jq --raw-input --slurp 'split("\u0000") | .[0:-1] | { path: . }' \
+    xargs -0 -n1 -I{} jq --null-input --arg filename {} '{ path: $filename }' \
     > "$TMPDIR/deletions.txt"
 
 SHA_BEFORE=$(git rev-parse HEAD)

--- a/commit.sh
+++ b/commit.sh
@@ -25,7 +25,7 @@ git diff -z --name-only --cached --no-renames --diff-filter=d | \
 
 # deletions
 git diff -z --name-only --cached --no-renames --diff-filter=D | \
-    jq --raw-input --slurp 'split("\u0000") | .[] | { path: . }' \
+    jq --raw-input --slurp 'split("\u0000") | .[0:-1] | { path: . }' \
     > "$TMPDIR/deletions.txt"
 
 SHA_BEFORE=$(git rev-parse HEAD)


### PR DESCRIPTION
```
gh: A path was requested for deletion which does not exist as of commit oid `e6be1c4116c258a6f63a36bd6621b3d277d30ef2`
+ COMMIT_URL='{"data":{"createCommitOnBranch":null},"errors":[{"type":"NOT_FOUND","path":["createCommitOnBranch"],"locations":[{"line":2,"column":9}],"message":"A path was requested for deletion which does not exist as of commit oid `e6be1c4116c258a6f63a36bd6621b3d277d30ef2`"}]}'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced handling of deleted files in the Git commit process with a more efficient approach.

- **Chores**
	- Maintained overall structure and functionality of the commit script, ensuring error handling and control flow remain intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->