### PR TITLE
fix: xargs warning

### DIFF
--- a/commit.sh
+++ b/commit.sh
@@ -26,7 +26,7 @@ git diff -z --name-only --cached --no-renames --diff-filter=d | \
 # deletions
 # shellcheck disable=SC2016
 git diff -z --name-only --cached --no-renames --diff-filter=D | \
-    xargs -0 -n1 -I{} jq --null-input --arg filename {} '{ path: $filename }' \
+    xargs -0 -I{} jq --null-input --arg filename {} '{ path: $filename }' \
     > "$TMPDIR/deletions.txt"
 
 SHA_BEFORE=$(git rev-parse HEAD)


### PR DESCRIPTION
> xargs: warning: options --max-args and --replace/-I/-i are mutually exclusive, ignoring previous --max-args value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Refined the internal processing for handling deletion events to improve consistency.
  - These enhancements optimize background operations while preserving current application behavior and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->